### PR TITLE
Update package.json :arrow_up: watch@1.0.2

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -61,6 +61,6 @@
     "reflux-state-mixin": "^0.7.0",
     "sinon": "^1.17.6",
     "sinon-chai": "^2.8.0",
-    "watch": "^0.19.2"
+    "watch": "^1.0.2"
   }
 }


### PR DESCRIPTION
Watch, e.g. via watchTree is used:
https://github.com/mongodb-js/khaos-compass-package/blob/108242be7b653452eca1acef3237d93ca37f56c9/template/electron/main/index.js#L23

Changes: 
https://github.com/mikeal/watch/compare/v0.19.3...v1.0.2

I don't think it matters how often the filesystem is polled:
https://github.com/mikeal/watch/tree/v1.0.2#watchwatchtreeroot-options-callback

Should resolve:
<img width="381" alt="screen shot 2017-04-28 at 3 09 55 pm" src="https://cloud.githubusercontent.com/assets/1217010/25543496/c37053f8-2c24-11e7-8d55-1ca02d8b96d1.png">
