### PR TITLE
COMPASS-1118 minor updates

### DIFF
--- a/template/.storybook/webpack.config.js
+++ b/template/.storybook/webpack.config.js
@@ -7,6 +7,14 @@ module.exports = {
       {
         test: /\.less$/,
         loader: 'style!css!less'
+      },
+      {
+        test: /\.woff(2)?(\?v=[0-9]\.[0-9]\.[0-9])?$/,
+        loader: 'url-loader?limit=10000&mimetype=application/font-woff'
+      },
+      {
+        test: /\.(ttf|eot|svg)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
+        loader: 'file-loader'
       }
     ]
   }

--- a/template/index.js
+++ b/template/index.js
@@ -14,14 +14,15 @@ const ROLE = {
  * Activate all the components in the {{capitalcase name}} package.
  */
 function activate() {
-  // Register the {{pascalcase name}}Component as a collection tab Role in Compass
+  // Register the {{pascalcase name}}Component as a role in Compass
   //
-  // Note that available roles are:
-  //   - Collection.Tab
-  //   - CollectionStats.CollectionStatsItem
-  //   - Database.Tab
+  // Available roles are:
   //   - Instance.Tab
-  //
+  //   - Database.Tab
+  //   - Collection.Tab
+  //   - CollectionHUD.Item
+  //   - Header.Item
+
   global.hadronApp.appRegistry.registerRole('{{role}}', ROLE);
   global.hadronApp.appRegistry.registerAction('{{pascalcase name}}.Actions', {{pascalcase name}}Actions);
   global.hadronApp.appRegistry.registerStore('{{pascalcase name}}.Store', {{pascalcase name}}Store);

--- a/template/package.json
+++ b/template/package.json
@@ -64,6 +64,7 @@
     "prop-types": "^15.5.8",
     "react": "^15.5.4",
     "react-dom": "^15.5.4",
+    "react-fontawesome": "^1.6.1",
     "reflux": "^0.4.1",
     "reflux-state-mixin": "^0.7.0",
     "sinon": "^1.17.6",

--- a/template/src/components/index.jsx
+++ b/template/src/components/index.jsx
@@ -2,6 +2,7 @@ const React = require('react');
 const { StoreConnector } = require('hadron-react-components');
 const {{pascalcase name}}Component = require('./{{name}}');
 const Store = require('../stores');
+const Actions = require('../actions');
 
 // const debug = require('debug')('mongodb-compass:{{slugcase name}}:index');
 
@@ -14,7 +15,7 @@ class Connected{{pascalcase name}}Component extends React.Component {
   render() {
     return (
       <StoreConnector store={Store}>
-        <{{pascalcase name}}Component />
+        <{{pascalcase name}}Component actions={Actions} {...this.props} />
       </StoreConnector>
     );
   }

--- a/template/src/components/{{name}}.jsx
+++ b/template/src/components/{{name}}.jsx
@@ -12,7 +12,7 @@ class {{pascalcase name}}Component extends React.Component {
   }
 
   /**
-   * Render RefluxCapacitor.
+   * Render {{pascalcase name}} component.
    *
    * @returns {React.Component} The rendered component.
    */

--- a/template/src/stores/index.js
+++ b/template/src/stores/index.js
@@ -11,6 +11,9 @@ const {{pascalcase name}}Store = Reflux.createStore({
   /**
    * adds a state to the store, similar to React.Component's state
    * @see https://github.com/yonatanmn/Super-Simple-Flux#reflux-state-mixin
+   *
+   * If you call `this.setState({...})` this will cause the store to trigger
+   * and push down its state as props to connected components.
    */
   mixins: [StateMixin.store],
 
@@ -26,24 +29,38 @@ const {{pascalcase name}}Store = Reflux.createStore({
   },
 
   /**
-   * This method is called when all packages are activated. Can be
-   * removed if not needed.
+   * This method is called when all plugins are activated. You can register
+   * listeners to other plugins' stores here, e.g.
+   *
+   * appRegistry.getStore('OtherPlugin.Store').listen(this.otherStoreChanged.bind(this));
+   *
+   * If this plugin does not depend on other stores, you can delete the method.
+   *
+   * @param {Object} appRegistry   app registry containing all stores and components
    */
-  onActivated() {
-    // Maybe go to the global.hadronApp.appRegistry and listen to other stores or actions?
+  onActivated(appRegistry) {
   },
 
   /**
-   * This method is called when the data service is finished connecting.
-   * If there is an error, the data service is not connected. If not, the
-   * passed data service is connected.
+   * This method is called when the data service is finished connecting. You
+   * receive either an error or the connected data service object, and if the
+   * connection was successful you can now make calls to the database, e.g.
+   *
+   * dataService.command('admin', {connectionStatus: 1}, this.handleStatus.bind(this));
+   *
+   * If this plugin does not need to talk to the database, you can delete this
+   * method.
+   *
+   * @param {Object} error         the error object if connection was unsuccessful
+   * @param {Object} dataService   the dataService object if connection was successful
+   *
    */
   onConnected(error, dataService) {
-    // this.dataService = dataService;
   },
 
   /**
-   * Initialize the {{capitalcase name}} store state.
+   * Initialize the {{capitalcase name}} store state. The returned object must
+   * contain all keys that you might want to modify with this.setState().
    *
    * @return {Object} initial store state.
    */
@@ -67,7 +84,7 @@ const {{pascalcase name}}Store = Reflux.createStore({
    * @param  {Object} prevState   previous state.
    */
   storeDidUpdate(prevState) {
-    debug('{{pascalcase name}} store changed from %j to %j', prevState, this.state);
+    debug('{{pascalcase name}} store changed from', prevState, 'to', this.state);
   }
 });
 

--- a/template/styles/index.less
+++ b/template/styles/index.less
@@ -1,2 +1,1 @@
-.{{slugcase name}} {
-}
+@import './{{name}}.less';

--- a/template/styles/{{name}}.less
+++ b/template/styles/{{name}}.less
@@ -1,2 +1,3 @@
 .{{slugcase name}} {
+  padding: 10px;
 }

--- a/template/styles/{{name}}.less
+++ b/template/styles/{{name}}.less
@@ -1,0 +1,2 @@
+.{{slugcase name}} {
+}


### PR DESCRIPTION
Some minor updates: 

- [x] in ./index.js update comments to updated list of roles
- [x] remove all references to RefluxCapacitor 
- [x] remove the %j in the storeDidUpdate debug statements, they are very inefficient. We are now just printing the objects directly.
    ```
    debug('ServerVersion store changed from', prevState, 'to', this.state);
    ```
- [x] pass actions and props into the connected component to create completely pure components, following this example: https://github.com/10gen/compass/blob/master/src/internal-packages/query/lib/component/index.jsx#L1-L24. This avoids having to require actions in lower-level components. They can instead just use this.props.actions.
- [x] include font-awesome and react-fontawesome and link so that it can be used without setup
move plugin specific styles in ((pascal-case name)).less and use index.less just to import styles.