### PR TITLE
Re-added hadron-react-components as a NPM dependency.

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -50,6 +50,7 @@
     "hadron-app": "^1.0.0",
     "hadron-app-registry": "^5.2.0",
     "hadron-build": "^9.1.0",
+    "hadron-react-components": "^1.9.1",
     "hadron-spectron": "^0.0.1",
     "jsdom": "^9.4.2",
     "less": "^2.7.1",


### PR DESCRIPTION
This [commit](https://github.com/mongodb-js/compass-plugin/commit/b675d21501621ac5ab856f9ada1fb9662b008994#diff-ebf2741126a75bcd0ccbf8df09b0f0fd) removed the dependency, but it is still used [here](https://github.com/mongodb-js/compass-plugin/blob/15ff5864c94ac84cfaa0ffffee332976a87ed048/template/src/components/index.jsx#L2). From this I assume it was simply a mistake, as creating a new plugin from scratch and running it after installing dependencies results in a JavaScript error and no output.

Installing the missing dependency resolves the issue. As a result, updating the package.json so that this is no longer an issue in the future.