### PR TITLE
[COMPASS-1761] Updated the webpack config CSS-Modules classnames output

### DIFF
--- a/template/config/webpack.dev.config.js
+++ b/template/config/webpack.dev.config.js
@@ -70,7 +70,7 @@ module.exports = {
             options: {
               modules: true,
               importLoaders: 1,
-              localIdentName: '{{pascalcase name}}__[name]_[local]__[hash:base64:5]'
+              localIdentName: '{{pascalcase name}}_[name]-[local]__[hash:base64:5]'
             }
           },
           {

--- a/template/config/webpack.prod.config.js
+++ b/template/config/webpack.prod.config.js
@@ -61,7 +61,7 @@ module.exports = {
               options: {
                 modules: true,
                 importLoaders: 1,
-                localIdentName: '{{pascalcase name}}__[hash:base64:5]'
+                localIdentName: '{{pascalcase name}}_[hash:base64:5]'
               }
             },
             {

--- a/template/config/webpack.test.config.js
+++ b/template/config/webpack.test.config.js
@@ -53,7 +53,7 @@ module.exports = {
             options: {
               modules: true,
               importLoaders: 1,
-              localIdentName: '{{pascalcase name}}__[name]_[local]__[hash:base64:5]'
+              localIdentName: '{{pascalcase name}}_[name]-[local]__[hash:base64:5]'
             }
           },
           {

--- a/template/config/webpack.watch.config.js
+++ b/template/config/webpack.watch.config.js
@@ -59,7 +59,7 @@ module.exports = {
             options: {
               modules: true,
               importLoaders: 1,
-              localIdentName: '{{pascalcase name}}__[name]_[local]__[hash:base64:5]'
+              localIdentName: '{{pascalcase name}}_[name]-[local]__[hash:base64:5]'
             }
           },
           {


### PR DESCRIPTION
This PR updates the CSS-modules classname output to be formatted in alignment with the [internal BEM guide](https://wiki.corp.mongodb.com/display/MMS/BEM+Guide).

In development the generated classnames will take this form:

```css
.[PluginName]_[FileName]-[local]__[hash:base64:5]
```
Where:
- PluginName = The name of the plugin (in pascal case).
- FileName = The name of the `.less` file (in pascal case).
- local = The CSS classname in the `.less` file
- hash = A base64 5 character generated hash unique in the global scope of the plugin.

And in production the generated classnames will take this form:

```css
.[PluginName]_[hash:base64:5]
```

__For example:__

For a compass-plugin called `FooBar`, and a component called `HelloWorld` would generate the following classnames:

```css
.FooBar_HelloWorld-component__3f4e3 {}

.FooBar_HelloWorld-button__23htr {}

.FooBar_HelloWorld-button-text_yEf83 {}
```

From the following `HelloWorld.less` file:

```less
.component {}

.button {
    &-text { }
}
```