### PR TITLE
[COMPASS-1857] Fix CI builds for compass-plugins generated from template

### DIFF
--- a/template/.babelrc
+++ b/template/.babelrc
@@ -1,8 +1,22 @@
 {
+  "env": {
+    "production": {
+      "presets": ["minify"]
+    },
+    "test": {
+      "presets": [
+        ["es2015"]
+      ],
+      "plugins": [
+        "react-hot-loader/babel",
+        "syntax-object-rest-spread",
+        "transform-class-properties"
+      ]
+    }
+  },
   "presets": [
     "react",
-    ['es2015', {'modules': false}],
-    "minify"
+    ['es2015', {'modules': false}]
   ],
   "plugins": [
     "react-hot-loader/babel",

--- a/template/.gitignore
+++ b/template/.gitignore
@@ -8,3 +8,4 @@ coverage
 .idea/
 *.iml
 .nvmrc
+.nyc_output

--- a/template/.travis.yml
+++ b/template/.travis.yml
@@ -16,7 +16,7 @@ before_script:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
   - npm run check
-script: npm run test
+script: npm run ci
 cache:
   directories:
     - $HOME/.electron

--- a/template/config/webpack.watch.config.js
+++ b/template/config/webpack.watch.config.js
@@ -110,6 +110,10 @@ module.exports = {
     ]
   },
   plugins: [
+    // Auto-create webpack externals for any dependency listed as a peerDependency in package.json
+    // so that the external vendor JavaScript is not part of our compiled bundle
+    new PeerDepsExternalsPlugin(),
+
     // Prints more readable module names in the browser console on HMR updates
     new webpack.NamedModulesPlugin(),
 

--- a/template/package.json
+++ b/template/package.json
@@ -14,7 +14,7 @@
     "test:watch": "cross-env NODE_ENV=test mocha-webpack \"./src/**/*.spec.js\" --watch",
     "test:karma": "cross-env NODE_ENV=test karma start",
     "cover": "nyc npm run test",
-    "ci": "npm run check && npm test",
+    "ci": "npm run check && npm run cover && npm run test:karma",
     "fmt": "mongodb-js-fmt ./*.js ./test/*.js",
     "precheck": "npm run compile",
     "check": "mongodb-js-precommit './src/**/*{.js,.jsx}' './test/**/*.js' './electron/**/*.js'",


### PR DESCRIPTION
- Updated configuration files so that tests correctly run in CI for generated plugins
- Added additional ignores to .gitignore so that generated files from NYC instrumentor are not tracked by git.
- Updated CI command in package.json
- Updated travis configuration so that it runs the CI command instead of just test
- Updated the .babelrc file so that tests correctly run