### PR TITLE
Handle native modules in plugins

### DIFF
--- a/template/config/webpack.dev.config.js
+++ b/template/config/webpack.dev.config.js
@@ -93,6 +93,10 @@ module.exports = {
           }
         ]
       },
+      {
+        test: /\.node$/,
+        use: 'node-loader'
+      },
       // For CSS-Modules locally scoped styles
       {
         test: /\.less$/,

--- a/template/config/webpack.karma.config.js
+++ b/template/config/webpack.karma.config.js
@@ -68,6 +68,10 @@ module.exports = {
           }
         ]
       },
+      {
+        test: /\.node$/,
+        use: 'node-loader'
+      },
       // For CSS-Modules locally scoped styles
       {
         test: /\.less$/,

--- a/template/config/webpack.prod.config.js
+++ b/template/config/webpack.prod.config.js
@@ -56,6 +56,10 @@ module.exports = {
           { loader: 'css-loader' }
         ]
       },
+      {
+        test: /\.node$/,
+        use: 'node-loader'
+      },
       // For styles that have to be global (see https://github.com/css-modules/css-modules/pull/65)
       {
         test: /\.less$/,

--- a/template/config/webpack.test.config.js
+++ b/template/config/webpack.test.config.js
@@ -35,6 +35,10 @@ module.exports = {
           { loader: 'css-loader' }
         ]
       },
+      {
+        test: /\.node$/,
+        use: 'node-loader'
+      },
       // For styles that have to be global (see https://github.com/css-modules/css-modules/pull/65)
       {
         test: /\.less$/,

--- a/template/config/webpack.watch.config.js
+++ b/template/config/webpack.watch.config.js
@@ -66,6 +66,10 @@ module.exports = {
             }
           },
           {
+            test: /\.node$/,
+            use: 'node-loader'
+          },
+          {
             loader: 'postcss-loader',
             options: {
               plugins: function() {

--- a/template/package.json
+++ b/template/package.json
@@ -91,6 +91,7 @@
     "mongodb-js-fmt": "^0.0.3",
     "mongodb-js-precommit": "^0.3.0",
     "mongodb-reflux-store": "0.0.1",
+    "node-loader": "^0.6.0",
     "nyc": "^11.0.3",
     "peer-deps-externals-webpack-plugin": "^1.0.2",
     "postcss-loader": "^2.0.6",


### PR DESCRIPTION
@aherlihy Pinging you so you can see the webpack configuration changes that needed to happen to allow this. Required the introduction of node-loader: https://github.com/webpack-contrib/node-loader