### PR TITLE
add babel-preset-es2015 to template

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -27,7 +27,9 @@
     "check"
   ],
   "dependency-check": {
-    "ignore": ["react-dom"]
+    "ignore": [
+      "react-dom"
+    ]
   },
   "license": "Apache-2.0",
   "peerDependencies": {
@@ -52,6 +54,7 @@
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
+    "babel-preset-es2015": "^6.24.1",
     "babel-preset-minify": "^0.2.0",
     "babel-preset-react": "^6.24.1",
     "babel-register": "^6.9.0",


### PR DESCRIPTION
a fresh npm install fails without this package in devDependencies \o/