### PR TITLE
remove babel-minify-webpack-plugin

### DIFF
--- a/template/config/webpack.prod.config.js
+++ b/template/config/webpack.prod.config.js
@@ -2,7 +2,6 @@ const webpack = require('webpack');
 const merge = require('webpack-merge');
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
-const MinifyPlugin = require('babel-minify-webpack-plugin');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const PeerDepsExternalsPlugin = require('peer-deps-externals-webpack-plugin');
 // const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
@@ -68,6 +67,10 @@ const config = {
       }
     ]
   },
+  optimization: {
+    // Minimize and uglify the code
+    minimize: true,
+  },
   plugins: [
     // Auto-create webpack externals for any dependency listed as a peerDependency in package.json
     // so that the external vendor JavaScript is not part of our compiled bundle
@@ -88,10 +91,6 @@ const config = {
 
     // Creates HTML page for us at build time
     new HtmlWebpackPlugin(),
-
-    // An ES6+ aware minifier, results in smaller output compared to UglifyJS given that
-    // Chromium in electron supports the majority of ES6 features out of the box.
-    new MinifyPlugin()
 
     // Uncomment to Analyze the output bundle size of the plugin. Useful for optimizing the build.
     // new BundleAnalyzerPlugin()

--- a/template/package.json
+++ b/template/package.json
@@ -14,7 +14,7 @@
     "test": "cross-env NODE_ENV=test mocha-webpack \"./src/**/*.spec.js\"",
     "test:watch": "cross-env NODE_ENV=test mocha-webpack \"./src/**/*.spec.js\" --watch",
     "test:karma": "cross-env NODE_ENV=test karma start",
-    "cover": "nyc npm run test",
+    "cover": "nyc npm run test && nyc report",
     "ci": "npm run cover && npm run test:karma && npm run compile && npm run check",
     "fmt": "mongodb-js-fmt ./*.js ./test/*.js",
     "check": "mongodb-js-precommit './src/**/*{.js,.jsx}' './test/**/*.js' './electron/**/*.js' './config/**/*{.js,.jsx}'",

--- a/template/package.json
+++ b/template/package.json
@@ -14,7 +14,7 @@
     "test": "cross-env NODE_ENV=test mocha-webpack \"./src/**/*.spec.js\"",
     "test:watch": "cross-env NODE_ENV=test mocha-webpack \"./src/**/*.spec.js\" --watch",
     "test:karma": "cross-env NODE_ENV=test karma start",
-    "cover": "nyc npm run test && nyc report",
+    "cover": "nyc npm run test",
     "ci": "npm run cover && npm run test:karma && npm run compile && npm run check",
     "fmt": "mongodb-js-fmt ./*.js ./test/*.js",
     "check": "mongodb-js-precommit './src/**/*{.js,.jsx}' './test/**/*.js' './electron/**/*.js' './config/**/*{.js,.jsx}'",

--- a/template/package.json
+++ b/template/package.json
@@ -50,7 +50,6 @@
     "babel-core": "^6.24.1",
     "babel-loader": "^7.1.1",
     "babel-minify": "^0.2.0",
-    "babel-minify-webpack-plugin": "^0.3.1",
     "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "babel-plugin-syntax-object-rest-spread": "^6.13.0",
     "babel-plugin-transform-class-properties": "^6.24.1",


### PR DESCRIPTION
so the new version of this plugin is kind of a bit broken, but you need the new version to run webpack-4.x otherwise it'll be even more broken. So! Proposal! I suggest just having the optimization flag in `prod` config to minify. It comes straight with webpack, so we don't have to do dependancy management ourselves. Under the hood this uses [webpack's terser plugin](https://webpack.js.org/plugins/terser-webpack-plugin/) which I think uses uglify.